### PR TITLE
Use HPA v2, update proxy

### DIFF
--- a/charts/evaluation-proxy/Chart.yaml
+++ b/charts/evaluation-proxy/Chart.yaml
@@ -9,10 +9,10 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.5"
+appVersion: "0.4.7"

--- a/charts/evaluation-proxy/templates/hpa.yaml
+++ b/charts/evaluation-proxy/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "evaluation-proxy.fullname" . }}
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
* Update the `hpa.yaml` template to use stable `apiVersion: autoscaling/v2`, supported by latest K8s engine across AWS, Google Cloud and Azure. This changes the average target utilization syntax somewhat.

* Update to the latest proxy patch version.
