### PR TITLE
SECENG-7700 [security] pinning actions and docker images

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
 
       - name: Lint
         run: helm lint charts/evaluation-proxy

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
 
@@ -29,13 +29,13 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
 
       - name: Helm Lint
         run: helm lint charts/evaluation-proxy
 
       - name: Set Chart Version
-        uses: jacobtomlinson/gha-find-replace@v2
+        uses: jacobtomlinson/gha-find-replace@f485fdc3f67a6d87ae6e3d11e41f648c26d7aee3 # v2
         with:
           find: 'version: .*'
           replace: 'version: ${{ github.event.inputs.chart-version }}'
@@ -43,7 +43,7 @@ jobs:
           regex: true
 
       - name: Set Proxy Version
-        uses: jacobtomlinson/gha-find-replace@v2
+        uses: jacobtomlinson/gha-find-replace@f485fdc3f67a6d87ae6e3d11e41f648c26d7aee3 # v2
         with:
           find: 'appVersion: ".*"'
           replace: 'appVersion: "${{ github.event.inputs.proxy-version }}"'
@@ -58,6 +58,6 @@ jobs:
           git push
 
       - name: Release Chart
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full-length commit SHAs to prevent supply chain attacks
- Pin Docker base images to digest SHAs where applicable

## Test plan
- [ ] Verify workflows run as expected after pinning

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only pins existing GitHub Actions to specific commit SHAs (no workflow logic changes), with the main risk being unexpected behavior if the pinned SHAs differ from the floating tags.
> 
> **Overview**
> Pins GitHub Actions used by the `lint` and `release` workflows to full commit SHAs instead of version tags (e.g., `actions/checkout`, `azure/setup-helm`, `jacobtomlinson/gha-find-replace`, `helm/chart-releaser-action`) to reduce supply-chain risk.
> 
> Workflow behavior remains the same; only the action references are made immutable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbec048e181642609aaa268ad88e7ebce383cc96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->